### PR TITLE
Generalize linking on Windows to work with different compilers/OpenMP.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,8 +1,11 @@
-LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
-
 PKG_CONFIG_CFLAGS = -DCURL_STATICLIB
-PKG_CONFIG_LIBS = -lgdal -larmadillo -lopenblas -lgomp -lmingwthrd -lgfortran -lquadmath -lgeotiff -lpoppler -lharfbuzz -lfreetype -lharfbuzz_too -lfreetype_too -lglib-2.0 -lintl -lwinmm -lole32 -lshlwapi -luuid -lpng -lgif -lnetcdf -lhdf5_hl -lblosc -llz4 -lgta -lmfhdf -lportablexdr -ldf -lkea -lhdf5_cpp -lhdf5 -lwsock32 -lsz -lopenjp2 -llcms2 -lpng16 -lpcre2-8 -lspatialite -ldl -lminizip -lbz2 -lmysqlclient -lpq -lpgcommon -lpgport -lshell32 -lsecur32 -lodbc32 -lodbccp32 -lfreexl -lexpat -lxml2 -lgeos_c -lgeos -lpsapi -lproj -lsqlite3 -ltiff -lwebp $(LIBSHARPYUV) -llzma -ljpeg -ljson-c -lstdc++ -lcurl -lidn2 -lunistring -liconv -lcharset -lssh2 -lgcrypt -lgpg-error -lbcrypt -ladvapi32 -lssl -lcrypto -lcrypt32 -lgdi32 -lwldap32 -lzstd -lz -lws2_32 -lpthread -lgsl -lgslcblas -lm
 
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+  PKG_CONFIG_LIBS = -lgdal -larmadillo -lopenblas -lmingwthrd -lgeotiff -lpoppler -lharfbuzz -lfreetype -lharfbuzz_too -lfreetype_too -lglib-2.0 -lintl -lwinmm -lole32 -lshlwapi -luuid -lpng -lgif -lnetcdf -lhdf5_hl -lblosc -llz4 -lgta -lmfhdf -lportablexdr -ldf -lkea -lhdf5_cpp -lhdf5 -lwsock32 -lsz -lopenjp2 -llcms2 -lpng16 -lpcre2-8 -lspatialite -ldl -lminizip -lbz2 -lmysqlclient -lpq -lpgcommon -lpgport -lshell32 -lsecur32 -lodbc32 -lodbccp32 -lfreexl -lexpat -lxml2 -lgeos_c -lgeos -lpsapi -lproj -lsqlite3 -ltiff -lwebp $(LIBSHARPYUV) -llzma -ljpeg -ljson-c -lstdc++ -lcurl -lidn2 -lunistring -liconv -lcharset -lssh2 -lgcrypt -lgpg-error -lbcrypt -ladvapi32 -lssl -lcrypto -lcrypt32 -lgdi32 -lwldap32 -lzstd -lz -lws2_32 -lpthread -lgsl -lgslcblas -lm $(FLIBS) $(SHLIB_OPENMP_CFLAGS)
+else
+  PKG_CONFIG_LIBS = $(shell pkg-config --libs gdal)
+endif
 
 PKG_CFLAGS += -DDLLEXPORT -D_USE_MATH_DEFINES -D_WIN32 \
 	-DWIN32 -DH5_BUILT_AS_DYNAMIC_LIB -DDLL_EXPORTS \


### PR DESCRIPTION
This generalizes the linking on Windows to support different compilers and OpenMP implementations via C preprocessor variables defined by R (assuming the fortran compiler and OpenMP library in the toolchain matches R, which is the case with Rtools). This is needed for building the package on Windows/aarch64 using LLVM.

This change also conditionally adds the use of pkg-config to establish the linking order: in that case, it is the responsibility of pkg-config to know the right Fortran and OpenMP libraries to use (the pkg-config part can be removed if needed, but it should reduce the frequency of needed updates to the linking -- supporting LLVM/aarch64 would not have required changes with pkg-config).
